### PR TITLE
Add auto-detection for Vero4k and 1 bug fix

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,6 +50,10 @@ endif
 # causing problems with keeping up to date with the repository.
 #
 #############################################################################
+
+# macro used by included Makefiles too
+bin_path=$(shell which $(1) 2> /dev/null)
+
 -include Makefile.q3lite
 -include Makefile.local
 
@@ -274,8 +278,6 @@ LOKISETUPDIR=misc/setup
 NSISDIR=misc/nsis
 SDLHDIR=$(MOUNT_DIR)/SDL2
 LIBSDIR=$(MOUNT_DIR)/libs
-
-bin_path=$(shell which $(1) 2> /dev/null)
 
 # We won't need this if we only build the server
 ifneq ($(BUILD_CLIENT),0)

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ ifeq ($(COMPILE_PLATFORM),sunos)
   COMPILE_ARCH=$(shell uname -p | sed -e 's/i.86/x86/')
 endif
 
+ifeq ($(shell sed -n '/^Hardware/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo),Vero4K)
+  # Standard arch test finds non-specific "aarch64" rather than "Vero4K"
+  PLATFORM_TYPE=vero4k
+  COMPILE_ARCH=vero4k
+endif
+
 ifndef BUILD_STANDALONE
   BUILD_STANDALONE =
 endif
@@ -353,6 +359,9 @@ ifneq (,$(findstring "$(PLATFORM)", "linux" "gnu_kfreebsd" "kfreebsd-gnu" "gnu")
     HAVE_VM_COMPILED=true
   endif
   ifeq ($(ARCH),armv7l)
+    HAVE_VM_COMPILED=true
+  endif
+  ifeq ($(ARCH),vero4k)
     HAVE_VM_COMPILED=true
   endif
   ifeq ($(ARCH),alpha)
@@ -2129,6 +2138,9 @@ ifeq ($(HAVE_VM_COMPILED),true)
   ifeq ($(ARCH),armv7l)
     Q3OBJ += $(B)/client/vm_armv7l.o
   endif
+  ifeq ($(ARCH),vero4k)
+    Q3OBJ += $(B)/client/vm_armv7l.o
+  endif
 endif
 
 ifdef MINGW
@@ -2310,6 +2322,9 @@ ifeq ($(HAVE_VM_COMPILED),true)
     Q3DOBJ += $(B)/ded/vm_sparc.o
   endif
   ifeq ($(ARCH),armv7l)
+    Q3DOBJ += $(B)/client/vm_armv7l.o
+  endif
+  ifeq ($(ARCH),vero4k)
     Q3DOBJ += $(B)/client/vm_armv7l.o
   endif
 endif

--- a/Makefile.q3lite
+++ b/Makefile.q3lite
@@ -35,6 +35,8 @@
 ifneq ($(PLATFORM_TYPE),)
   ifeq ($(shell uname -m),armv7l)
     override ARCH=armv7l
+  else ifeq ($(shell sed -n '/^Hardware/s/^.*: \(.*\)/\1/p' < /proc/cpuinfo),Vero4K)
+    override ARCH=vero4k
   else
     override ARCH=arm
   endif
@@ -141,12 +143,18 @@ endif
     PI_CFLAGS=-march=armv8-a+crc -mfpu=vfpv4 -mtune=cortex-a53
   endif
   CFLAGS += -DHAVE_GLES $(PI_CFLAGS) -mfloat-abi=hard -Ofast -I/opt/vc/include
+  ifeq ($(PLATFORM_TYPE),vero4k) # Vero4k overide all priorCFLAGS
+    CFLAGS =-march=armv8-a+crc -mtune=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard -ftree-vectorize -funsafe-math-optimizations
+    CFLAGS += -DHAVE_GLES -I/opt/vero3/include
+  endif
   ifneq ($(wildcard /opt/vc/lib/libbrcmEGL.so),)
     ifneq ($(wildcard /opt/vc/lib/libbrcmGLESv2.so),)
       LDFLAGS += -L/opt/vc/lib -lbrcmEGL -lbrcmGLESv2
     else
       LDFLAGS += -L/opt/vc/lib -lEGL -lGLESv2
     endif
+  else ifneq ($(wildcard /opt/vero3/lib/libMali.so),) # Vero4k
+    LDFLAGS += -L/opt/vero3/lib -lMali
   else
     LDFLAGS += -L/opt/vc/lib -lEGL -lGLESv2
   endif


### PR DESCRIPTION
Add auto-detection for Vero4k...

FIX: A macro `bin_path` was being borrowed from Makefile by Makefile.q3lite but was undefined at the time of its use.  The result is incorrectly blank, but goes unnoticed on an RPi as it's likely the desired behavior.